### PR TITLE
Fix setup menu interactivity

### DIFF
--- a/app/js/setup-ui.js
+++ b/app/js/setup-ui.js
@@ -1,0 +1,24 @@
+// setup-ui.js - ensures setup menu interactions work
+(function() {
+  function startGame() {
+    if (window.PhaseManager && typeof PhaseManager.transitionTo === 'function') {
+      if (typeof PhaseManager.applyGameSettings === 'function') {
+        PhaseManager.applyGameSettings();
+      }
+      PhaseManager.transitionTo(PhaseManager.PHASES.INTRO);
+    }
+  }
+
+  function init() {
+    var btn = document.getElementById('start-game-btn');
+    if (btn) {
+      btn.addEventListener('click', startGame);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/app/js/setup.js
+++ b/app/js/setup.js
@@ -1,0 +1,2 @@
+// setup.js - placeholder to avoid missing script errors
+console.log('setup.js loaded');


### PR DESCRIPTION
## Summary
- add missing `setup.js` and `setup-ui.js` scripts
- new setup UI script handles the start button and applies settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca009e048322b283933391dac90b