### PR TITLE
Fix SaveSystem script injection in init.js

### DIFF
--- a/app/js/init.js
+++ b/app/js/init.js
@@ -27,11 +27,14 @@ body {
 document.head.appendChild(emojiFontStyle);
 
 
-    
-    // First, add the SaveSystem module
-    const saveSystemScript = document.createElement('script');
-    saveSystemScript.innerHTML = SaveSystem.toString().replace('const SaveSystem = ', 'window.SaveSystem = ') + ';';
-    document.head.appendChild(saveSystemScript);
+
+    // Ensure SaveSystem is available
+    if (!window.SaveSystem) {
+        console.warn('SaveSystem not found, attempting to load dynamically');
+        const saveSystemScript = document.createElement('script');
+        saveSystemScript.src = 'js/save-system.js';
+        document.head.appendChild(saveSystemScript);
+    }
     
     // Apply our fixes
     function applyGameFixes() {


### PR DESCRIPTION
## Summary
- check if `SaveSystem` is already loaded
- load `save-system.js` dynamically only if needed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841de4d47948322b0dc50b0a8894d40