### PR TITLE
Add Test Game quick-start button

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -155,6 +155,7 @@
 
 <script src="js/setup-ui.js"></script>
 <script src="js/init.js"></script> <!-- This initializes everything -->
+<script src="js/test-game-button.js"></script>
 
 
 </body>

--- a/app/js/test-game-button.js
+++ b/app/js/test-game-button.js
@@ -1,0 +1,63 @@
+(function() {
+  function createButton() {
+    const btn = document.createElement('button');
+    btn.id = 'test-game-button';
+    btn.textContent = 'Test Game';
+    Object.assign(btn.style, {
+      position: 'fixed',
+      top: '10px',
+      left: '50%',
+      transform: 'translateX(-50%)',
+      zIndex: '10000',
+      padding: '8px 16px',
+      fontSize: '16px',
+      background: '#ff5722',
+      color: '#fff',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer'
+    });
+
+    btn.addEventListener('click', function() {
+      btn.style.display = 'none';
+
+      try {
+        localStorage.setItem('sudoku_game_settings', JSON.stringify({
+          style: 'defense',
+          difficulty: 'easy'
+        }));
+        localStorage.setItem('sudoku_td_character', 'alchemist');
+      } catch (e) {
+        console.error('Unable to save test game settings', e);
+      }
+
+      if (window.AbilitySystem && typeof AbilitySystem.selectCharacter === 'function') {
+        AbilitySystem.selectCharacter('alchemist');
+      }
+
+      if (window.LevelsModule && typeof LevelsModule.setDifficulty === 'function') {
+        LevelsModule.setDifficulty('easy');
+      }
+
+      if (window.BoardManager && typeof BoardManager.init === 'function') {
+        BoardManager.init({ difficulty: 'easy', style: 'defense' });
+      }
+
+      if (window.PhaseManager && typeof PhaseManager.transitionTo === 'function') {
+        PhaseManager.transitionTo(PhaseManager.PHASES.SUDOKU);
+      }
+
+      if (window.Game && typeof Game.updateUI === 'function') {
+        Game.updateUI();
+      }
+    });
+
+    document.body.appendChild(btn);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', createButton);
+  } else {
+    createButton();
+  }
+})();


### PR DESCRIPTION
## Summary
- overlay a `Test Game` button for quick startup
- clicking it sets Sudoku Defense on easy difficulty with the alchemist character

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841e0c787c4832289cfa31bde1f1fae