### PR TITLE
Improve puzzle layout for larger screens

### DIFF
--- a/app/css/core/styles.css
+++ b/app/css/core/styles.css
@@ -2352,7 +2352,7 @@ h1 {
 /* === Main Game Grid === */
 .steam-deck-layout {
     display: grid;
-    grid-template-columns: minmax(100px, 20%) minmax(350px, 60%) minmax(150px, 20%);
+    grid-template-columns: minmax(80px, 10%) minmax(0, 80%) minmax(80px, 10%);
     grid-template-rows: 1fr;
     width: 100%;
     height: calc(100% - 45px); /* Account for header */
@@ -2393,7 +2393,7 @@ h1 {
 /* === Sudoku Board === */
 #sudoku-board {
     width: 100%;
-    max-width: 100%;
+    max-width: 80vw;
     max-height: 100%;
     aspect-ratio: 1;
     margin: 0 auto;
@@ -2530,7 +2530,7 @@ h1 {
 /* === Responsive Adjustments === */
 @media (max-width: 768px) {
     .steam-deck-layout {
-        grid-template-columns: minmax(80px, 25%) minmax(200px, 50%) minmax(100px, 25%);
+        grid-template-columns: minmax(60px, 15%) 1fr minmax(60px, 15%);
     }
     
     .tower-option {

--- a/app/css/platform/steam-deck-layout.css
+++ b/app/css/platform/steam-deck-layout.css
@@ -82,7 +82,7 @@ h1 {
 /* === Main Game Grid === */
 .steam-deck-layout {
     display: grid;
-    grid-template-columns: minmax(100px, 20%) minmax(350px, 60%) minmax(150px, 20%);
+    grid-template-columns: minmax(80px, 10%) minmax(0, 80%) minmax(80px, 10%);
     grid-template-rows: 1fr;
     width: 100%;
     height: calc(100% - 45px); /* Account for header */
@@ -123,7 +123,7 @@ h1 {
 /* === Sudoku Board === */
 #sudoku-board {
     width: 100%;
-    max-width: 100%;
+    max-width: 80vw;
     max-height: 100%;
     aspect-ratio: 1;
     margin: 0 auto;
@@ -260,7 +260,7 @@ h1 {
 /* === Responsive Adjustments === */
 @media (max-width: 768px) {
     .steam-deck-layout {
-        grid-template-columns: minmax(80px, 25%) minmax(200px, 50%) minmax(100px, 25%);
+        grid-template-columns: minmax(60px, 15%) 1fr minmax(60px, 15%);
     }
     
     .tower-option {

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -37,13 +37,16 @@
 @media (min-width: 768px) {
     #layout-grid {
         /*
-         * Allocate more space to the Sudoku board on medium and larger
-         * screens so that it consistently occupies at least half of the
-         * available width. The side columns are reduced to 160px each,
-         * giving the board the majority of the layout.
+         * Give the puzzle the lion's share of the width. The side columns
+         * shrink down to roughly 10% of the viewport each (never smaller
+         * than 80px) so the board can occupy close to 80%.
          */
-        grid-template-columns: 160px 1fr 160px;
+        grid-template-columns: minmax(80px, 10%) 1fr minmax(80px, 10%);
         align-items: start;
+    }
+
+    #sudoku-board {
+        max-width: 80vw;
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust responsive layout so the Sudoku board can use about 80% of the screen
- tweak Steam Deck styles for same board emphasis
- keep side panels compact on all widths

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e39c127c832287e8731f9f20f146