### PR TITLE
Remove leftover instructional comments

### DIFF
--- a/app/css/core/styles.css
+++ b/app/css/core/styles.css
@@ -1692,7 +1692,6 @@ background-image: url('../assets/bunker.png') !important;
 
 /**
  * Character Ability Visual Effects CSS
- * Add this to your styles.css file or include as a separate stylesheet
  */
 
 /* === Base Effect Styles === */

--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,7 @@
 </head>
 <body>
     <h1>Sudoku Tower Defense</h1>
-    <!-- Add this HTML code before the game-container in index.html -->
+    <!-- Setup menu displayed before the game starts -->
 <div id="setup-menu">
     <div class="setup-container">
         <h2>Sudoku Game Setup</h2>

--- a/app/js/ability-system.js
+++ b/app/js/ability-system.js
@@ -358,11 +358,11 @@ const AbilitySystem = (function() {
     if (existingIndicator) existingIndicator.remove();
     createCharacterIndicatorUI();
     
-    // Add this to the AbilitySystem.selectCharacter function in ability-system.js
-// Place at the end of the function before the "return true;" line:
-if (window.EventSystem) {
-  EventSystem.publish('character:selected', characterId);
-}
+
+    // Notify other modules that the character was selected
+    if (window.EventSystem) {
+        EventSystem.publish('character:selected', characterId);
+    }
   
     
     return true;
@@ -590,13 +590,9 @@ if (window.EventSystem) {
     return false;
   }
   /**
- * Simple fix for abilities not triggering completion bonuses
- * 
- * Just update the placeTowerWithBoardSync function to explicitly check
- * for completions after placing a tower.
- */
-
-// Replace the existing placeTowerWithBoardSync function with this improved version
+   * Place a tower while keeping the board state in sync and
+   * checking for unit completions.
+   */
 function placeTowerWithBoardSync(value, row, col, options = {}) {
   const boardManager = window.BoardManager;
   const towersModule = window.TowersModule;

--- a/app/js/completion-bonus.js
+++ b/app/js/completion-bonus.js
@@ -5,7 +5,7 @@
  * - Makes Continue button reset game and prompt for new character selection
  */
  
- // Add these variables near the top of your IIFE (after any existing let declarations)
+ // Combo system state
 let comboCount = 0;
 let comboTimer = null;
 let comboBonusMultiplier = 0.2; // 20% bonus per combo level
@@ -300,10 +300,8 @@ let hasCelebrated = false;
     document.head.appendChild(style);
   }
   
-  // Add this function to handle the combo system
-// Updated function to handle the combo system with proper timer
-// Add this to your code to debug the combo system
-function debugComboSystem() {
+  // Debug helper for the combo system
+  function debugComboSystem() {
   console.log("=== COMBO SYSTEM DEBUG ===");
   console.log(`Current combo count: ${comboCount}`);
   console.log(`Max combo reached: ${comboMaxReached}`);
@@ -322,7 +320,6 @@ function debugComboSystem() {
   return "Check browser console for debug info";
 }
 
-// Add this to window for access in console
 window.debugComboSystem = debugComboSystem;
 
 // Modify handleCombo to track timer creation time
@@ -397,7 +394,7 @@ function handleCombo() {
   };
 }
 
-// Add this function to add styles for the combo system
+// Styles for visualizing the combo system
 function addComboStyles() {
   if (document.getElementById('combo-styles')) return;
   
@@ -874,9 +871,8 @@ function showComboMessage(combo) {
   
   // Reset game and prompt for new character
   /**
- * Updates to completion-bonus.js to integrate with PhaseManager
- * Find these functions in your completion-bonus.js file and modify them
- */
+   * Integration with PhaseManager for celebration flow
+   */
 
 // Update this function to work with PhaseManager
 function resetGameAfterCelebration() {
@@ -1255,8 +1251,7 @@ function onUnitCompleted(unitType, unitIndex) {
 }
   
   /**
-   * Add this to your completion-bonus.js file to add lightweight animations
-   * for row, column, and grid completions
+   * Lightweight animations for row, column and grid completions
    */
   
   // === ADD THESE FUNCTIONS INSIDE YOUR MAIN IIFE ===
@@ -1371,7 +1366,7 @@ function addCompletionAnimationStyles() {
       message.remove();
     }, 1500);
   }
-  // Add this function to your code
+  // Styles for lines connecting completed units
 function addConnectedLineStyles() {
   if (document.getElementById('connected-line-styles')) return;
   
@@ -1406,7 +1401,7 @@ function addConnectedLineStyles() {
   document.head.appendChild(style);
 }
 
-// Add this function to your code
+// Draw an animated line connecting completed cells
 function drawConnectingLine(cells, unitType) {
   // Create SVG container
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -1975,8 +1970,6 @@ function animateUnitCompletion(unitType, unitIndex, bonusAmount, comboCount = 1)
   
   // Hook into game events
   // Hook into game events
-  // Add this to the bottom of completion-bonus.js or modify your existing function
-  
   /**
    * Hook into game events with explicit animation calls
    */

--- a/app/js/enemies.js
+++ b/app/js/enemies.js
@@ -1958,10 +1958,8 @@ function createDefeatParticles(enemy, enemyEl) {
     }
     
     /**
- * This code needs to be added to make the status effects visible on enemies.
- * Add this to the end of your enemies.js file or at the end of your game.js file
- * where the renderEnemies function is defined.
- */
+     * Visual helpers for enemy status effects
+     */
 
 // Apply status effect visuals to enemies
 function applyStatusEffectsVisuals() {

--- a/app/js/game.js
+++ b/app/js/game.js
@@ -1,4 +1,3 @@
-// Add this at the beginning of the Game module to ensure events are properly initialized
 const Game = (function() {
     // Private variables
     let isInitialized = false;
@@ -540,7 +539,6 @@ function setupUIEventListeners() {
 
 /**
  * Add a debug button to the UI (optional)
- * Add this to your game.js file in the setupUIEventListeners function
  */
 // Add debug solution button for development
 function addDebugSolutionButton() {
@@ -730,8 +728,8 @@ document.getElementById('new-game').addEventListener('click', function() {
   });
   
 /**
- * Modify the GameEvents.GAME_OVER subscription in game.js
- * Replace the existing handler with this one in the setupEventListeners function
+ * Handle GameEvents.GAME_OVER by transitioning phases and
+ * saving the final score.
  */
 
 

--- a/app/js/init.js
+++ b/app/js/init.js
@@ -371,8 +371,7 @@ setTimeout(() => {
 });
 
 /**
- * Add this code to the end of your init.js file, before the final closing brace
- * This initializes the phase manager and fixes the game flow
+ * Initialize the phase manager to keep the game flow consistent
  */
 
 // Initialize the Phase Manager 

--- a/app/js/stats-screen.js
+++ b/app/js/stats-screen.js
@@ -1,6 +1,5 @@
 /**
  * Game Statistics Screen - Shows player statistics and achievements
- * Add this to your game and incorporate with a "Stats" button in your UI
  */
 
 const StatsScreen = (function() {

--- a/app/js/tower-animations.js
+++ b/app/js/tower-animations.js
@@ -1,6 +1,6 @@
 /**
- * A simplified fix that reverts to the original position calculation but ensures first wave projectiles.
- * Replace your tower-animations.js with this version.
+ * Simplified tower animation logic that restores original
+ * position calculation while ensuring first-wave projectiles.
  */
  
  function getTowerTypeData(towerType) {
@@ -122,9 +122,6 @@ const TowerAnimationsModule = (function() {
      * @param {Object} enemy - The enemy object
      * @returns {Object} Position {x, y} relative to the board
      */
-/**
- * Drop this function into your tower-animations.js file to replace the current calculateEnemyPosition function
- */
 function calculateEnemyPosition(enemy) {
     // Check if enemy has direct x,y coordinates
     if (enemy && typeof enemy.x === 'number' && typeof enemy.y === 'number') {
@@ -608,7 +605,7 @@ function createHitEffect(projectile, effectType) {
     };
 })();
 
-// Add this to window for global access
+// Expose the module globally
 window.TowerAnimationsModule = TowerAnimationsModule;
 
 // Add CSS styles for tower attack animations

--- a/app/js/towers.js
+++ b/app/js/towers.js
@@ -9,11 +9,10 @@ const TowersModule = (function() {
     let towerId = 0;
     let cellSize = 0;
     
-    // Tower types with their properties - ENHANCED DAMAGE VERSION
+    // Tower types with their properties - enhanced version
   /**
- * Tower types with specialized behaviors
- * Replace the existing towerTypes object in towers.js with this enhanced version
- */
+   * Tower types with specialized behaviors
+   */
 const towerTypes = {
   // 1: Fast-firing "machine gun" towers with low damage but high attack speed
   1: {
@@ -155,54 +154,13 @@ const towerTypes = {
     }
     
     /**
-     * Create a new tower
+     * Create a new tower. Allows placement that may violate Sudoku rules so
+     * incorrect towers can be removed later.
      * @param {number|string} type - Tower type
      * @param {number} row - Row index on the grid
      * @param {number} col - Column index on the grid
      * @returns {Object|null} The created tower or null if creation failed
      */
-    /**
- * Update for the TowersModule to allow strategic placement of towers
- * that violate Sudoku rules.
- */
-
-/**
- * Create a new tower
- * @param {number|string} type - Tower type
- * @param {number} row - Row index on the grid
- * @param {number} col - Column index on the grid
- * @returns {Object|null} The created tower or null if creation failed
- */
-/**
- * Create a new tower
- * @param {number|string} type - Tower type
- * @param {number} row - Row index on the grid
- * @param {number} col - Column index on the grid
- * @returns {Object|null} The created tower or null if creation failed
- */
-/**
- * Create a new tower
- * @param {number|string} type - Tower type
- * @param {number} row - Row index on the grid
- * @param {number} col - Column index on the grid
- * @returns {Object|null} The created tower or null if creation failed
- */
-/**
- * Create a new tower with improved validation and UI updates
- * @param {number|string} type - Tower type
- * @param {number} row - Row index on the grid
- * @param {number} col - Column index on the grid
- * @returns {Object|null} The created tower or null if creation failed
- */
-/**
- * Add this code to your TowersModule to fix incorrect tower removal
- * Place these functions inside the TowersModule IIFE
- */
-
-/**
- * Tracking recent tower placements to influence enemy paths
- * Add this to the createTower function in TowersModule
- */
 function createTower(type, row, col, options = {}) {
     const { free = false } = options;
     console.log(`Creating tower: Type=${type}, Position=(${row},${col})`);
@@ -320,7 +278,7 @@ function createTower(type, row, col, options = {}) {
             window.recentTowerPlacements = [];
         }
         
-        // Add this placement to recent towers
+        // Track this placement for path generation
         window.recentTowerPlacements.push({ row, col, type });
         
         // Keep the list manageable (last 5 placements)
@@ -344,7 +302,7 @@ function createTower(type, row, col, options = {}) {
     return tower;
 }
 
-// Replace your removeIncorrectTowers function with this version
+// Remove any towers that don't match the Sudoku solution
 function removeIncorrectTowers() {
   console.log("Checking for incorrect towers to remove...");
   console.log(`Currently tracking ${incorrectTowers.size} incorrect towers`);
@@ -433,7 +391,7 @@ function removeIncorrectTowers() {
   }
 }
 
-// Add this to your initEventListeners function or create it if it doesn't exist
+// Initialize event listeners for tower-related actions
 function initEventListeners() {
   // Listen for game initialization
   EventSystem.subscribe(GameEvents.GAME_INIT, function(options) {
@@ -463,7 +421,7 @@ function initEventListeners() {
   }
 }
 
-// Add this to your Event Subscription for better visual indicators
+// Highlight newly placed towers that don't match the puzzle
 EventSystem.subscribe(GameEvents.TOWER_PLACED, function(tower) {
   if (tower && tower.id && incorrectTowers.has(tower.id)) {
     // Add visual indicator for incorrect towers


### PR DESCRIPTION
## Summary
- clean up redundant block comments in towers.js
- trim outdated guidance comments from several modules
- keep concise documentation across JS, CSS, and HTML

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e301090c8322821a3b17a07f8b55