### PR TITLE
Redesigned main UI layout

### DIFF
--- a/app/css/gameplay/board/sudoku-board-select.css
+++ b/app/css/gameplay/board/sudoku-board-select.css
@@ -61,9 +61,11 @@
 /* Mode toggle button */
 #sudoku-mode-toggle {
   position: fixed;
-  top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 80px;
+  right: 20px;
+  left: auto;
+  top: auto;
+  transform: none;
   background-color: #333;
   color: white;
   border: none;
@@ -98,9 +100,11 @@
 /* Mode indicator tooltip */
 #mode-indicator {
   position: fixed;
-  top: 50px;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 120px;
+  right: 20px;
+  left: auto;
+  top: auto;
+  transform: none;
   background-color: rgba(0,0,0,0.7);
   color: white;
   padding: 8px 15px;

--- a/app/css/ui/mission-control.css
+++ b/app/css/ui/mission-control.css
@@ -40,3 +40,8 @@
   border-top: 1px solid #444;
   margin: 5px 0;
 }
+
+#mission-control.overlay {
+  width: 100%;
+  border-radius: 10px 10px 0 0;
+}

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -28,10 +28,16 @@
     gap: 1rem;
 }
 
+.right-column {
+    display: none;
+}
+
 .middle-column {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+    gap: 1rem;
 }
 
 @media (min-width: 768px) {
@@ -65,4 +71,40 @@
     width: 100%;
     max-width: 100%;
     aspect-ratio: 1;
+}
+
+.middle-column #tower-selection {
+    width: 100%;
+    max-width: 360px;
+}
+
+.next-wave {
+    margin-top: 0.5rem;
+}
+
+#mission-control.overlay {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transform: translateY(100%);
+    transition: transform 0.3s;
+    z-index: 1000;
+}
+
+#mission-control.overlay.open {
+    transform: translateY(0);
+}
+
+.mission-toggle {
+    position: fixed;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    z-index: 1100;
+    background: #333;
+    color: #fff;
+    border: none;
+    border-radius: 20px;
+    padding: 6px 12px;
+    cursor: pointer;
 }

--- a/app/index.html
+++ b/app/index.html
@@ -77,23 +77,11 @@
 
         <div id="layout-grid">
             <div class="left-column">
-                <div id="tower-selection">
-  <div class="tower-option" data-tower-type="1" title="Rapid Tower: Fast-firing with 3x attack speed but lower damage">1️⃣</div>
-  <div class="tower-option" data-tower-type="2" title="Slowing Tower: Reduces enemy speed by 30% for 3 seconds">2️⃣</div>
-  <div class="tower-option" data-tower-type="3" title="Splash Tower: Damages multiple enemies in a small radius">3️⃣</div>
-  <div class="tower-option" data-tower-type="4" title="Poison Tower: Applies damage over time effect">4️⃣</div>
-  <div class="tower-option" data-tower-type="5" title="Pierce Tower: Effective against armored enemies">5️⃣</div>
-  <div class="tower-option" data-tower-type="6" title="Stun Tower: 25% chance to freeze enemies for 1 second">6️⃣</div>
-  <div class="tower-option" data-tower-type="7" title="Gambling Tower: Random chance for bonus damage or currency">7️⃣</div>
-  <div class="tower-option" data-tower-type="8" title="Sniper Tower: Long range with 20% chance for critical hits">8️⃣</div>
-  <div class="tower-option" data-tower-type="9" title="Support Tower: Boosts damage of adjacent towers by 20%">9️⃣</div>
-                </div>
                 <div id="game-info">
                     <div>Currency: <span id="currency-value">100</span></div>
                     <div id="status-message">Place towers to defend against enemies!</div>
                 </div>
                 <div id="game-controls">
-                    <button id="start-wave">Start Wave</button>
                     <button id="pause-game">Pause</button>
                     <select id="font-selector" title="Change game font">
                         <option value="font-default" class="font-default">Default Font</option>
@@ -107,16 +95,28 @@
             </div>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
-            </div>
-            <div class="right-column">
-                <div id="mission-control">
-    <h3>Mission Control</h3>
-    <ul id="mission-tips">
-        <li>Scanning board...</li>
-    </ul>
+                <div id="tower-selection">
+  <div class="tower-option" data-tower-type="1" title="Rapid Tower: Fast-firing with 3x attack speed but lower damage">1️⃣</div>
+  <div class="tower-option" data-tower-type="2" title="Slowing Tower: Reduces enemy speed by 30% for 3 seconds">2️⃣</div>
+  <div class="tower-option" data-tower-type="3" title="Splash Tower: Damages multiple enemies in a small radius">3️⃣</div>
+  <div class="tower-option" data-tower-type="4" title="Poison Tower: Applies damage over time effect">4️⃣</div>
+  <div class="tower-option" data-tower-type="5" title="Pierce Tower: Effective against armored enemies">5️⃣</div>
+  <div class="tower-option" data-tower-type="6" title="Stun Tower: 25% chance to freeze enemies for 1 second">6️⃣</div>
+  <div class="tower-option" data-tower-type="7" title="Gambling Tower: Random chance for bonus damage or currency">7️⃣</div>
+  <div class="tower-option" data-tower-type="8" title="Sniper Tower: Long range with 20% chance for critical hits">8️⃣</div>
+  <div class="tower-option" data-tower-type="9" title="Support Tower: Boosts damage of adjacent towers by 20%">9️⃣</div>
                 </div>
+                <button id="start-wave" class="next-wave">Next Wave</button>
             </div>
+            <div class="right-column"></div>
         </div>
+        <div id="mission-control" class="overlay">
+            <h3>Mission Control</h3>
+            <ul id="mission-tips">
+                <li>Scanning board...</li>
+            </ul>
+        </div>
+        <button id="mission-toggle" class="mission-toggle">Mission Control</button>
     </div>
 <p></p>
 <p></p>
@@ -154,6 +154,7 @@
 <script src="js/sudoku-board-select.js"></script>
 
 <script src="js/setup-ui.js"></script>
+<script src="js/main-ui-reframe.js"></script>
 <script src="js/init.js"></script> <!-- This initializes everything -->
 <script src="js/test-game-button.js"></script>
 

--- a/app/js/main-ui-reframe.js
+++ b/app/js/main-ui-reframe.js
@@ -1,0 +1,13 @@
+// main-ui-reframe.js
+// Handles new UI interactions for the redesigned layout
+(function() {
+  document.addEventListener('DOMContentLoaded', function() {
+    const panel = document.getElementById('mission-control');
+    const toggle = document.getElementById('mission-toggle');
+    if (panel && toggle) {
+      toggle.addEventListener('click', function() {
+        panel.classList.toggle('open');
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- reposition the sudoku board controls and mission panel
- allow mission control to toggle from the bottom
- move number/tower selection beneath the puzzle
- float the sudoku mode button and indicator near the board

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5297a2c83228332ebea6f1fde02