### PR TITLE
Fix asset references for tower and emoji font

### DIFF
--- a/app/css/core/styles.css
+++ b/app/css/core/styles.css
@@ -190,7 +190,8 @@ h1 {
 .tower {
     width: 32px;
     height: 32px;
-    background-image: url('../assets/spritesheet4.png');
+    /* Correct path so sprites load when served from /app */
+    background-image: url('../../assets/spritesheet4.png');
     background-size: 98px 98px;
     background-repeat: no-repeat;
     display: inline-block;
@@ -235,7 +236,8 @@ h1 {
 .enemy-sprite {
   transform-origin: top left;
   transform: scale(var(--enemy-scale, .3));
-  background-image: url("../assets/enemy-sprites.png");
+  /* Correct path so enemy sprites load from /app */
+  background-image: url("../../assets/enemy-sprites.png");
   background-repeat: no-repeat;
   background-size: 768px 1152px;
   width: 256px;
@@ -453,7 +455,8 @@ h1 {
 }
 
 .enemy.preview {
-  background-image: url("../assets/enemy-sprites.png") !important;
+  /* Correct path for preview sprite */
+  background-image: url("../../assets/enemy-sprites.png") !important;
   background-repeat: no-repeat;
   background-size: 768px 1152px;
   background-position: 0px 0px; /* test type 1 */
@@ -1632,7 +1635,8 @@ button:active {
 
 .sudoku-cell.grass {
   background-color: #6ab04c !important; /* soft green fallback */
-  background-image: url('../assets/grass2.png') !important;
+  /* Correct path so grid grass tiles load */
+  background-image: url('../../assets/grass2.png') !important;
   background-size: cover !important;
   background-repeat: no-repeat !important;
   background-position: center !important;
@@ -1640,7 +1644,8 @@ button:active {
 
 .sudoku-cell.dirt {
   background-color: #b5835a !important; /* dirt brown fallback */
-  background-image: url('../assets/dirt2.png') !important;
+  /* Correct path for dirt texture */
+  background-image: url('../../assets/dirt2.png') !important;
   background-size: cover !important;
   background-repeat: no-repeat !important;
   background-position: center !important;
@@ -1655,7 +1660,8 @@ button:active {
 
 .sudoku-cell.fixed-block {
   background-color: #2e7d32 !important; /* Dark green fallback */
-  background-image: url('../assets/bunker.png') !important;
+  /* Correct path for bunker tile */
+  background-image: url('../../assets/bunker.png') !important;
   background-size: cover !important;
   background-repeat: no-repeat !important;
   background-position: center !important;
@@ -1663,7 +1669,8 @@ button:active {
 
 .sudoku-cell.dark-grass {
   background-color: #2e7d32 !important; /* Dark green fallback */
-background-image: url('../assets/bunker.png') !important;
+  /* Correct path for dark grass tile */
+  background-image: url('../../assets/bunker.png') !important;
   background-size: cover !important;
   background-repeat: no-repeat !important;
   background-position: center !important;

--- a/app/css/gameplay/towers/enhanced-tower-rotation.css
+++ b/app/css/gameplay/towers/enhanced-tower-rotation.css
@@ -9,7 +9,8 @@
   transition: transform 0.2s ease-out;
   pointer-events: none;
 
-  background-image: url("assets/aimsheet3.png");
+  /* Use absolute path so the image resolves correctly when served from /app */
+  background-image: url("../../../assets/aimsheet3.png");
   background-size: 96px 96px;
   background-repeat: no-repeat;
   image-rendering: pixelated;

--- a/app/js/init.js
+++ b/app/js/init.js
@@ -18,7 +18,8 @@ const emojiFontStyle = document.createElement('style');
 emojiFontStyle.textContent = `
 @font-face {
   font-family: 'NotoColorEmoji';
-  src: url('assets/fonts/NotoColorEmoji-Regular.ttf') format('truetype');
+  /* Use an absolute path so the font loads correctly from the /app root */
+  src: url('/assets/fonts/NotoColorEmoji-Regular.ttf') format('truetype');
 }
 body {
   font-family: 'NotoColorEmoji', 'Segoe UI Emoji', 'Apple Color Emoji', sans-serif;


### PR DESCRIPTION
## Summary
- correct tower barrel sprite path so images load
- use absolute path for emoji font in init script

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e80459bc8322afd39c03420b5ee0