### PR TITLE
Add portrait mission control overlay

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -82,20 +82,6 @@
     margin-top: 0.5rem;
 }
 
-#mission-control.overlay {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    transform: translateY(100%);
-    transition: transform 0.3s;
-    z-index: 1000;
-}
-
-#mission-control.overlay.open {
-    transform: translateY(0);
-}
-
 .mission-toggle {
     position: fixed;
     bottom: 0.5rem;
@@ -107,4 +93,25 @@
     border-radius: 20px;
     padding: 6px 12px;
     cursor: pointer;
+}
+
+@media (orientation: portrait) {
+    #mission-control.overlay {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        transform: translateY(100%);
+        transition: transform 0.3s;
+        z-index: 1000;
+    }
+
+    #mission-control.overlay.open {
+        transform: translateY(0);
+    }
+
+    #mission-toggle {
+        bottom: 0.5rem;
+        right: 0.5rem;
+    }
 }


### PR DESCRIPTION
## Summary
- relocate the mission control overlay for portrait viewports
- keep toggle button accessible on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ef6923d883228c14af923e667cd9