### PR TITLE
Add mission control toggle

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -98,11 +98,14 @@
 
 #mission-control.overlay {
     transform: translateX(100%);
-    transition: transform 0.3s;
+    visibility: hidden;
+    transition: transform 0.3s, visibility 0s linear 0.3s;
 }
 
 #mission-control.overlay.open {
     transform: translateX(0);
+    visibility: visible;
+    transition: transform 0.3s;
 }
 
 @media (orientation: portrait) {
@@ -112,12 +115,15 @@
         left: 0;
         right: 0;
         transform: translateY(100%);
-        transition: transform 0.3s;
+        visibility: hidden;
+        transition: transform 0.3s, visibility 0s linear 0.3s;
         z-index: 1000;
     }
 
     #mission-control.overlay.open {
         transform: translateY(0);
+        visibility: visible;
+        transition: transform 0.3s;
     }
 
     #mission-toggle {

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -82,6 +82,7 @@
     margin-top: 0.5rem;
 }
 
+
 .mission-toggle {
     position: fixed;
     bottom: 0.5rem;
@@ -93,6 +94,15 @@
     border-radius: 20px;
     padding: 6px 12px;
     cursor: pointer;
+}
+
+#mission-control.overlay {
+    transform: translateX(100%);
+    transition: transform 0.3s;
+}
+
+#mission-control.overlay.open {
+    transform: translateX(0);
 }
 
 @media (orientation: portrait) {

--- a/app/index.html
+++ b/app/index.html
@@ -110,13 +110,13 @@
             </div>
             <div class="right-column"></div>
         </div>
-        <div id="mission-control" class="overlay">
+        <div id="mission-control" class="overlay open">
             <h3>Mission Control</h3>
             <ul id="mission-tips">
                 <li>Scanning board...</li>
             </ul>
         </div>
-        <button id="mission-toggle" class="mission-toggle">Mission Control</button>
+        <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
     </div>
 <p></p>
 <p></p>

--- a/app/js/main-ui-reframe.js
+++ b/app/js/main-ui-reframe.js
@@ -7,6 +7,11 @@
     if (panel && toggle) {
       toggle.addEventListener('click', function() {
         panel.classList.toggle('open');
+        if (panel.classList.contains('open')) {
+          toggle.textContent = 'Hide Tips';
+        } else {
+          toggle.textContent = 'Show Tips';
+        }
       });
     }
   });


### PR DESCRIPTION
## Summary
- allow toggling Mission Control visibility with a slide effect
- update toggle button label based on panel state
- start the panel open by default

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f0fd4b448322b86950a3d5d5e172