### PR TITLE
Add Jest tests for core modules

### DIFF
--- a/test/board-state.test.js
+++ b/test/board-state.test.js
@@ -1,0 +1,51 @@
+const path = require('path');
+
+function createEmptyGrid(val=0){
+  return Array.from({length:9},()=>Array(9).fill(val));
+}
+
+beforeEach(() => {
+  global.window = {};
+  jest.resetModules();
+
+  // simple PathGenerator stub
+  window.PathGenerator = {
+    getPathCells: () => new Set(['1,1'])
+  };
+  global.PathGenerator = window.PathGenerator;
+
+  require(path.join('..','app','js','board-state.js'));
+  require(path.join('..','app','js','puzzle-generator.js'));
+});
+
+describe('BoardState basic operations', () => {
+  test('setCellValue respects fixed and path cells', () => {
+    const solution = window.PuzzleGenerator.generateCompleteSolution();
+    const board = createEmptyGrid();
+    const fixed = createEmptyGrid(false);
+    fixed[0][0] = true;
+    window.BoardState.setState(board, solution, fixed);
+
+    // fixed cell cannot be changed
+    const resultFixed = window.BoardState.setCellValue(0,0,5);
+    expect(resultFixed).toBe(false);
+
+    // path cell cannot be changed
+    const resultPath = window.BoardState.setCellValue(1,1,5);
+    expect(resultPath).toBe(false);
+
+    // valid cell can be changed and retrieved
+    const result = window.BoardState.setCellValue(2,2,7);
+    expect(result).toBe(true);
+    const boardAfter = window.BoardState.getBoard();
+    expect(boardAfter[2][2]).toBe(7);
+  });
+
+  test('isComplete detects solved board', () => {
+    const solution = window.PuzzleGenerator.generateCompleteSolution();
+    window.BoardState.setState(solution, solution, createEmptyGrid(false));
+    expect(window.BoardState.isComplete()).toBe(true);
+    window.BoardState.setCellValue(0,0,0);
+    expect(window.BoardState.isComplete()).toBe(false);
+  });
+});

--- a/test/path-generator.test.js
+++ b/test/path-generator.test.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+beforeEach(() => {
+  global.window = {};
+  jest.resetModules();
+  require(path.join('..','app','js','path-generator.js'));
+});
+
+describe('PathGenerator.generateEnemyPath', () => {
+  test('creates a path from column 0 to 8 with unique cells', () => {
+    const pathArr = window.PathGenerator.generateEnemyPath(13);
+    expect(pathArr[0][1]).toBe(0); // start at column 0
+    const last = pathArr[pathArr.length-1];
+    expect(last[1]).toBe(8); // end column
+
+    // ensure uniqueness
+    const set = new Set(pathArr.map(p=>p.join(',')));
+    expect(set.size).toBe(pathArr.length);
+  });
+});

--- a/test/puzzle-generator.test.js
+++ b/test/puzzle-generator.test.js
@@ -1,0 +1,50 @@
+const path = require('path');
+
+beforeEach(() => {
+  global.window = {};
+  jest.resetModules();
+  require(path.join('..','app','js','puzzle-generator.js'));
+});
+
+describe('PuzzleGenerator.generateCompleteSolution', () => {
+  test('produces a valid completed sudoku', () => {
+    const grid = window.PuzzleGenerator.generateCompleteSolution();
+    expect(grid).toHaveLength(9);
+    grid.forEach(row => expect(row).toHaveLength(9));
+
+    // rows contain 1..9
+    grid.forEach(row => {
+      const sorted = [...row].sort();
+      expect(sorted).toEqual([1,2,3,4,5,6,7,8,9]);
+    });
+
+    // columns contain 1..9
+    for(let c=0;c<9;c++){
+      const col = grid.map(r => r[c]).sort();
+      expect(col).toEqual([1,2,3,4,5,6,7,8,9]);
+    }
+  });
+});
+
+describe('PuzzleGenerator.createPuzzleFromSolution', () => {
+  test('hides cells not to reveal and keeps path cells empty', () => {
+    // deterministic Math.random
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    const solution = window.PuzzleGenerator.generateCompleteSolution();
+    const path = new Set(['0,0','0,1']);
+    const { puzzle, fixed } = window.PuzzleGenerator.createPuzzleFromSolution(solution, path, 5);
+
+    // path cells should be zero and not fixed
+    expect(puzzle[0][0]).toBe(0);
+    expect(puzzle[0][1]).toBe(0);
+    expect(fixed[0][0]).toBe(false);
+    expect(fixed[0][1]).toBe(false);
+
+    // exactly 5 fixed cells
+    const countFixed = fixed.flat().filter(Boolean).length;
+    expect(countFixed).toBe(5);
+
+    Math.random.mockRestore();
+  });
+});

--- a/test/towers.test.js
+++ b/test/towers.test.js
@@ -1,0 +1,74 @@
+const path = require('path');
+
+function setup() {
+  global.window = {};
+  jest.useFakeTimers();
+  jest.resetModules();
+
+  window.EventSystem = { publish: jest.fn(), subscribe: jest.fn() };
+  window.GameEvents = { STATUS_MESSAGE:'status', TOWER_PLACED:'placed', TOWER_REMOVED:'removed' };
+  global.EventSystem = window.EventSystem;
+  global.GameEvents = window.GameEvents;
+
+  global.document = {
+    addEventListener: jest.fn(),
+    querySelectorAll: jest.fn(() => []),
+    querySelector: jest.fn(() => null),
+    createElement: jest.fn(() => ({ style:{}, classList:{add:jest.fn(), remove:jest.fn()}, appendChild:jest.fn(), parentNode:null, cloneNode:jest.fn(()=>({})) })),
+    body: { appendChild: jest.fn() }
+  };
+  window.document = global.document;
+
+  const fixed = Array.from({length:9},()=>Array(9).fill(false));
+  const pathCells = new Set();
+  const board = Array.from({length:9},()=>Array(9).fill(0));
+  const solution = Array.from({length:9},()=>Array(9).fill(1));
+
+  window.BoardManager = {
+    getFixedCells: () => fixed,
+    getPathCells: () => pathCells,
+    getSolution: () => solution,
+    setCellValue: jest.fn(() => true),
+    getBoard: () => board
+  };
+  global.BoardManager = window.BoardManager;
+
+  window.PlayerModule = {
+    getState: jest.fn(() => ({ currency: 100 })),
+    spendCurrency: jest.fn(),
+    addCurrency: jest.fn()
+  };
+  global.PlayerModule = window.PlayerModule;
+
+  require(path.join('..','app','js','towers.js'));
+  return { fixed, pathCells };
+}
+
+describe('TowersModule placement and removal', () => {
+  test('createTower places tower when valid', () => {
+    setup();
+    const tower = window.TowersModule.createTower('1',0,0);
+    jest.runOnlyPendingTimers();
+    expect(tower).toBeTruthy();
+    expect(window.BoardManager.setCellValue).toHaveBeenCalledWith(0,0,1);
+    expect(window.TowersModule.getTowerAt(0,0)).toBeTruthy();
+  });
+
+  test('createTower fails on fixed cell', () => {
+    const { fixed } = setup();
+    fixed[0][0] = true;
+    const tower = window.TowersModule.createTower('1',0,0);
+    expect(tower).toBeNull();
+    expect(window.BoardManager.setCellValue).not.toHaveBeenCalled();
+  });
+
+  test('removeTower clears cell and list', () => {
+    setup();
+    const tower = window.TowersModule.createTower('1',0,0);
+    jest.runOnlyPendingTimers();
+    const result = window.TowersModule.removeTower(tower.id);
+    expect(result).toBe(true);
+    expect(window.BoardManager.setCellValue).toHaveBeenLastCalledWith(0,0,0);
+    expect(window.TowersModule.getTowerAt(0,0)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add puzzle generator tests
- add board state tests
- add path generator tests
- add tower module tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f142de1483229157d03919a4990c