### PR TITLE
Refactor game layout semantics

### DIFF
--- a/app/css/platform/steam-deck-layout.css
+++ b/app/css/platform/steam-deck-layout.css
@@ -90,7 +90,7 @@ h1 {
 }
 
 /* Left column for tower selection and controls */
-.left-column {
+aside.left-column {
     display: flex;
     flex-direction: column;
     background-color: rgba(0, 0, 0, 0.05);
@@ -111,7 +111,7 @@ h1 {
 }
 
 /* Right column for mission control */
-.right-column {
+aside.right-column {
     display: flex;
     flex-direction: column;
     background-color: rgba(0, 0, 0, 0.05);
@@ -283,7 +283,7 @@ h1 {
         grid-template-rows: auto 1fr auto;
     }
     
-    .left-column {
+    aside.left-column {
         grid-row: 3;
         border-right: none;
         border-top: 1px solid #ccc;
@@ -295,7 +295,7 @@ h1 {
         grid-row: 2;
     }
     
-    .right-column {
+    aside.right-column {
         grid-row: 1;
         border-left: none;
         border-bottom: 1px solid #ccc;
@@ -385,14 +385,14 @@ h1 {
 }
 
 /* Debugging outlines - remove in production */
-.debug .left-column,
+.debug aside.left-column,
 .debug .middle-column,
-.debug .right-column {
+.debug aside.right-column {
     outline: 1px dashed red;
 }
 
 /* Compact left column styles for Steam Deck */
-body.steam-deck-mode .left-column {
+body.steam-deck-mode aside.left-column {
     padding: 5px;
     gap: 5px;
     max-width: 100%;
@@ -471,7 +471,7 @@ body.steam-deck-mode #tower-selection {
 
 
 /* Optimize mission control for Steam Deck */
-body.steam-deck-mode .right-column {
+body.steam-deck-mode aside.right-column {
     padding: 5px;
     overflow-y: auto;
 }

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -21,14 +21,14 @@
     gap: 1rem;
 }
 
-.left-column,
-.right-column {
+aside.left-column,
+aside.right-column {
     display: flex;
     flex-direction: column;
     gap: 1rem;
 }
 
-.right-column {
+aside.right-column {
     display: none;
 }
 

--- a/app/index.html
+++ b/app/index.html
@@ -68,15 +68,16 @@
 </div>
     <div id="game-container">
         <div id="phase-indicator" class="phase-banner"></div>
-        <div id="game-header">
+        <header id="game-header">
             <div id="score">Score: <span id="score-value">0</span></div>
             <div id="lives">Lives: <span id="lives-value">3</span></div>
             <div id="wave">Wave: <span id="wave-value">1</span></div>
-            
-        </div>
 
+        </header>
+
+        <main id="game-area">
         <div id="layout-grid">
-            <div class="left-column">
+            <aside class="left-column">
                 <div id="game-info">
                     <div>Currency: <span id="currency-value">100</span></div>
                     <div id="status-message">Place towers to defend against enemies!</div>
@@ -92,7 +93,7 @@
                     </select>
                     <button id="new-game">New Game</button>
                 </div>
-            </div>
+            </aside>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
                 <div id="tower-selection">
@@ -108,8 +109,9 @@
                 </div>
                 <button id="start-wave" class="next-wave">Next Wave</button>
             </div>
-            <div class="right-column"></div>
+            <aside class="right-column"></aside>
         </div>
+        </main>
         <div id="mission-control" class="overlay open">
             <h3>Mission Control</h3>
             <ul id="mission-tips">
@@ -118,11 +120,7 @@
         </div>
         <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
     </div>
-<p></p>
-<p></p>
 <p>Made by YanniMakes </p>
-<p></p>
-<p></p>
     <!-- Load the modules in the correct order -->
 <script src="js/events.js"></script>
 <script src="js/phase-manager.js"></script>


### PR DESCRIPTION
## Summary
- use a `<header>` for the game stats
- wrap board grid inside `<main id="game-area">`
- convert sidebar columns to `<aside>` elements
- remove stray empty paragraphs
- update CSS selectors for new `<aside>` elements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f65e2e5c83228f39b7ea71db37e2