### PR TITLE
Add canvas renderer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ npm test
 ```
 
 This will execute all test suites located in the `test/` directory.
+
+## Canvas renderer
+
+A basic canvas renderer is included in `app/js/render-canvas.js`. It draws towers, enemies, and projectiles on an HTML5 canvas overlay instead of using DOM elements. The module automatically starts when the page loads and exposes a `logFPSComparison()` method to print the current DOM and canvas frame rates to the console.
+
+Call `CanvasRenderer.logFPSComparison()` in the browser console to compare performance between the DOM and canvas implementations.

--- a/app/index.html
+++ b/app/index.html
@@ -143,6 +143,7 @@
 <script src="js/game.js"></script>
 <script src="js/completion-bonus.js"></script>
 <script src="js/enhanced-tower-rotation.js"></script>
+<script src="js/render-canvas.js"></script>
 <script src="js/setup.js"></script>
 <script src="js/steam-deck-implementation.js"></script>
 

--- a/app/js/render-canvas.js
+++ b/app/js/render-canvas.js
@@ -1,0 +1,187 @@
+const CanvasRenderer = (function() {
+  let canvas, ctx;
+  let cellSize = 0;
+  let animationId = null;
+  let lastTime = 0;
+  let fps = 0;
+  let frameCount = 0;
+  let fpsTime = 0;
+  const projectiles = [];
+
+  function init(options = {}) {
+    const board = document.getElementById('sudoku-board');
+    if (!board) return;
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.id = 'game-canvas';
+      canvas.style.position = 'absolute';
+      canvas.style.left = '0';
+      canvas.style.top = '0';
+      board.appendChild(canvas);
+      ctx = canvas.getContext('2d');
+    }
+    resize();
+    window.addEventListener('resize', resize);
+    if (window.EventSystem && window.GameEvents) {
+      EventSystem.subscribe(GameEvents.TOWER_ATTACK, onTowerAttack);
+    }
+  }
+
+  function resize() {
+    const board = document.getElementById('sudoku-board');
+    if (!board || !canvas) return;
+    canvas.width = board.clientWidth;
+    canvas.height = board.clientHeight;
+    cellSize = canvas.width / 9;
+  }
+
+  function start() {
+    if (!animationId) {
+      lastTime = performance.now();
+      animationId = requestAnimationFrame(loop);
+    }
+  }
+
+  function stop() {
+    if (animationId) {
+      cancelAnimationFrame(animationId);
+      animationId = null;
+    }
+  }
+
+  function loop(timestamp) {
+    const delta = timestamp - lastTime;
+    lastTime = timestamp;
+    frameCount++;
+    fpsTime += delta;
+    if (fpsTime >= 1000) {
+      fps = (frameCount * 1000) / fpsTime;
+      frameCount = 0;
+      fpsTime = 0;
+    }
+    draw(delta);
+    animationId = requestAnimationFrame(loop);
+  }
+
+  function draw(delta) {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawTowers();
+    drawEnemies();
+    updateProjectiles(delta);
+    drawProjectiles();
+  }
+
+  function drawTowers() {
+    if (!window.TowersModule || !TowersModule.getTowers) return;
+    const towers = TowersModule.getTowers();
+    ctx.fillStyle = '#008800';
+    towers.forEach(t => {
+      const x = t.col * cellSize;
+      const y = t.row * cellSize;
+      ctx.fillRect(x + cellSize * 0.1, y + cellSize * 0.1, cellSize * 0.8, cellSize * 0.8);
+    });
+  }
+
+  function drawEnemies() {
+    if (!window.EnemiesModule || !EnemiesModule.getEnemies) return;
+    const enemies = EnemiesModule.getEnemies();
+    ctx.fillStyle = '#880000';
+    enemies.forEach(e => {
+      const x = e.col * cellSize;
+      const y = e.row * cellSize;
+      ctx.fillRect(x + cellSize * 0.2, y + cellSize * 0.2, cellSize * 0.6, cellSize * 0.6);
+    });
+  }
+
+  function onTowerAttack(data) {
+    if (!data || !data.tower || !data.enemy) return;
+    const startX = data.tower.col * cellSize + cellSize / 2;
+    const startY = data.tower.row * cellSize + cellSize / 2;
+    const projectile = {
+      enemyId: data.enemy.id,
+      x: startX,
+      y: startY,
+      progress: 0,
+      speed: 0.005
+    };
+    projectiles.push(projectile);
+  }
+
+  function updateProjectiles(delta) {
+    if (!window.EnemiesModule || !EnemiesModule.getEnemies) return;
+    const enemies = EnemiesModule.getEnemies();
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p = projectiles[i];
+      const enemy = enemies.find(e => e.id === p.enemyId);
+      if (!enemy) {
+        projectiles.splice(i, 1);
+        continue;
+      }
+      const targetX = enemy.col * cellSize + cellSize / 2;
+      const targetY = enemy.row * cellSize + cellSize / 2;
+      p.progress += p.speed * delta;
+      if (p.progress >= 1) {
+        projectiles.splice(i, 1);
+        continue;
+      }
+      p.x += (targetX - p.x) * p.progress;
+      p.y += (targetY - p.y) * p.progress;
+    }
+  }
+
+  function drawProjectiles() {
+    ctx.fillStyle = '#ffff00';
+    projectiles.forEach(p => {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, cellSize * 0.1, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  }
+
+  function getFPS() {
+    return fps;
+  }
+
+  function logFPSComparison() {
+    if (typeof window.getDOMFPS === 'function') {
+      console.log(`DOM FPS: ${window.getDOMFPS().toFixed(1)} Canvas FPS: ${fps.toFixed(1)}`);
+    } else {
+      console.log(`Canvas FPS: ${fps.toFixed(1)}`);
+    }
+  }
+
+  return {
+    init,
+    start,
+    stop,
+    getFPS,
+    logFPSComparison
+  };
+})();
+
+window.CanvasRenderer = CanvasRenderer;
+
+(function(){
+  let last = performance.now();
+  let frames = 0;
+  let fps = 0;
+  function domLoop(now){
+    frames++;
+    if(now - last >= 1000){
+      fps = frames * 1000 / (now - last);
+      frames = 0;
+      last = now;
+    }
+    requestAnimationFrame(domLoop);
+  }
+  requestAnimationFrame(domLoop);
+  window.getDOMFPS = function(){ return fps; };
+})();
+
+document.addEventListener('DOMContentLoaded', function(){
+  if(window.CanvasRenderer){
+    CanvasRenderer.init();
+    CanvasRenderer.start();
+  }
+});

--- a/test/render-canvas.test.js
+++ b/test/render-canvas.test.js
@@ -1,0 +1,32 @@
+const path = require('path');
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+function setupDom() {
+  global.window = {};
+  global.document = {
+    getElementById: jest.fn(() => ({ clientWidth: 450, appendChild: jest.fn() })),
+    createElement: jest.fn(() => ({ style: {}, getContext: jest.fn(() => ({ clearRect: jest.fn(), fillRect: jest.fn(), beginPath: jest.fn(), arc: jest.fn(), fill: jest.fn() })) })),
+    addEventListener: jest.fn()
+  };
+  window.document = global.document;
+  window.EventSystem = { subscribe: jest.fn() };
+  window.GameEvents = { TOWER_ATTACK: 'attack' };
+  global.requestAnimationFrame = jest.fn(cb => {
+    if (cb) setTimeout(() => cb(0), 0);
+    return 1;
+  });
+  global.cancelAnimationFrame = jest.fn();
+}
+
+describe('CanvasRenderer', () => {
+  test('exposes init and start functions', () => {
+    setupDom();
+    require(path.join('..','app','js','render-canvas.js'));
+    expect(window.CanvasRenderer).toBeDefined();
+    expect(typeof window.CanvasRenderer.init).toBe('function');
+    expect(typeof window.CanvasRenderer.start).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `render-canvas.js` that draws towers, enemies and projectiles on a canvas
- start the renderer automatically and provide FPS comparison helper
- expose new script in `index.html`
- document usage in README
- add basic test for the new module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fe472da4832289bf7d934b09cfb8