### PR TITLE
Improve mobile UI

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -76,10 +76,56 @@ aside.right-column {
 .middle-column #tower-selection {
     width: 100%;
     max-width: 360px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+}
+
+@media (min-width: 768px) {
+    .middle-column #tower-selection {
+        display: flex;
+    }
 }
 
 .next-wave {
     margin-top: 0.5rem;
+}
+
+#bottom-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    grid-column: 1 / -1;
+}
+
+#bottom-controls #tower-selection li.tower-option {
+    width: 100%;
+}
+
+@media (min-width: 768px) {
+    .middle-column #tower-selection {
+        display: flex;
+    }
+    #bottom-controls #tower-selection li.tower-option {
+        width: calc(10% - 8px);
+    }
+}
+
+@media (max-width: 480px) {
+    #bottom-controls {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: #fff;
+        padding: 0.5rem;
+        box-shadow: 0 -2px 5px rgba(0,0,0,0.2);
+        z-index: 1000;
+    }
+
+    #game-container {
+        padding-bottom: 140px;
+    }
 }
 
 

--- a/app/index.html
+++ b/app/index.html
@@ -96,6 +96,9 @@
             </aside>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
+            </div>
+            <aside class="right-column"></aside>
+            <div id="bottom-controls">
                 <ul id="tower-selection">
   <li class="tower-option" data-tower-type="1" title="Rapid Tower: Fast-firing with 3x attack speed but lower damage">1️⃣</li>
   <li class="tower-option" data-tower-type="2" title="Slowing Tower: Reduces enemy speed by 30% for 3 seconds">2️⃣</li>
@@ -109,7 +112,6 @@
                 </ul>
                 <button id="start-wave" class="next-wave">Next Wave</button>
             </div>
-            <aside class="right-column"></aside>
         </div>
         </main>
         <div id="mission-control" class="overlay open">


### PR DESCRIPTION
## Summary
- create fixed bottom controls for tower selection and wave button
- reorganize layout in index.html to add `#bottom-controls`
- add responsive styling for new mobile-friendly design

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842036b310483228a75775d1d62066b