### PR TITLE
Move gameplay controls to toggleable menu

### DIFF
--- a/app/css/ui/game-menu.css
+++ b/app/css/ui/game-menu.css
@@ -1,0 +1,38 @@
+#game-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 220px;
+  max-height: 100vh;
+  background-color: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 1rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+#game-menu.overlay {
+  transform: translateX(-100%);
+  visibility: hidden;
+  transition: transform 0.3s, visibility 0s linear 0.3s;
+}
+
+#game-menu.overlay.open {
+  transform: translateX(0);
+  visibility: visible;
+  transition: transform 0.3s;
+}
+
+.menu-toggle {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1100;
+  background: #333;
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  padding: 6px 12px;
+  cursor: pointer;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -26,6 +26,7 @@
 <link rel="stylesheet" href="css/ui/game-ui.css">
 <link rel="stylesheet" href="css/ui/mission-control.css">
 <link rel="stylesheet" href="css/ui/player-effects.css">
+<link rel="stylesheet" href="css/ui/game-menu.css">
 <link rel="stylesheet" href="css/ui/stats-screen.css">
 <link rel="stylesheet" href="css/ui/responsive-layout.css">
 </head>
@@ -82,17 +83,7 @@
                     <div>Currency: <span id="currency-value">100</span></div>
                     <div id="status-message">Place towers to defend against enemies!</div>
                 </div>
-                <nav id="game-controls">
-                    <button id="pause-game">Pause</button>
-                    <select id="font-selector" title="Change game font">
-                        <option value="font-default" class="font-default">Default Font</option>
-                        <option value="font-retro" class="font-retro">Retro Font</option>
-                        <option value="font-elegant" class="font-elegant">Elegant Font</option>
-                        <option value="font-playful" class="font-playful">Playful Font</option>
-                        <option value="font-modern" class="font-modern">Modern Font</option>
-                    </select>
-                    <button id="new-game">New Game</button>
-                </nav>
+
             </aside>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
@@ -112,6 +103,20 @@
             <aside class="right-column"></aside>
         </div>
         </main>
+        <div id="game-menu" class="overlay">
+            <nav id="game-controls">
+                <button id="pause-game">Pause</button>
+                <select id="font-selector" title="Change game font">
+                    <option value="font-default" class="font-default">Default Font</option>
+                    <option value="font-retro" class="font-retro">Retro Font</option>
+                    <option value="font-elegant" class="font-elegant">Elegant Font</option>
+                    <option value="font-playful" class="font-playful">Playful Font</option>
+                    <option value="font-modern" class="font-modern">Modern Font</option>
+                </select>
+                <button id="new-game">New Game</button>
+            </nav>
+        </div>
+        <button id="menu-toggle" class="menu-toggle">Menu</button>
         <div id="mission-control" class="overlay open">
             <h3>Mission Control</h3>
             <ul id="mission-tips">

--- a/app/js/main-ui-reframe.js
+++ b/app/js/main-ui-reframe.js
@@ -4,6 +4,8 @@
   document.addEventListener('DOMContentLoaded', function() {
     const panel = document.getElementById('mission-control');
     const toggle = document.getElementById('mission-toggle');
+    const menu = document.getElementById('game-menu');
+    const menuToggle = document.getElementById('menu-toggle');
     if (panel && toggle) {
       toggle.addEventListener('click', function() {
         panel.classList.toggle('open');
@@ -12,6 +14,13 @@
         } else {
           toggle.textContent = 'Show Tips';
         }
+      });
+    }
+
+    if (menu && menuToggle) {
+      menuToggle.addEventListener('click', function() {
+        menu.classList.toggle('open');
+        menuToggle.textContent = menu.classList.contains('open') ? 'Close Menu' : 'Menu';
       });
     }
   });

--- a/app/js/test-game-button.js
+++ b/app/js/test-game-button.js
@@ -4,11 +4,6 @@
     btn.id = 'test-game-button';
     btn.textContent = 'Test Game';
     Object.assign(btn.style, {
-      position: 'fixed',
-      top: '10px',
-      left: '50%',
-      transform: 'translateX(-50%)',
-      zIndex: '10000',
       padding: '8px 16px',
       fontSize: '16px',
       background: '#ff5722',
@@ -52,7 +47,12 @@
       }
     });
 
-    document.body.appendChild(btn);
+    const controls = document.getElementById('game-controls');
+    if (controls) {
+      controls.appendChild(btn);
+    } else {
+      document.body.appendChild(btn);
+    }
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- add a new *game menu* overlay for non‑gameplay buttons
- toggle overlay with a new menu button
- update `test-game-button.js` to insert into the new menu
- style the menu with `game-menu.css`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b68111a08322a687b0397739a685