### PR TITLE
Remove board clearing on new wave

### DIFF
--- a/app/js/board-state.js
+++ b/app/js/board-state.js
@@ -126,10 +126,6 @@ const BoardState = (function() {
           fixes++;
         }
 
-        if (pathCells.has(key) && board[r][c] !== 0) {
-          board[r][c] = 0;
-          fixes++;
-        }
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent board cells from being overwritten with `0` when switching phases

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb3b93d88322bcc5bb39abda2e63