### PR TITLE
Remove LFS pointer for emoji font

### DIFF
--- a/app/assets/Noto_Color_Emoji.zip
+++ b/app/assets/Noto_Color_Emoji.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5ab59684b672980ca3f9f65df2d33a9f67f16fea0dc039784ee3457c48b0468
-size 24278789


### PR DESCRIPTION
## Summary
- remove `app/assets/Noto_Color_Emoji.zip`
- keep using `NotoColorEmoji-Regular.ttf` via injected font-face rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842be8fae4883228aa672c248d5ea45