### PR TITLE
Add utility bar UI

### DIFF
--- a/app/css/gameplay/board/sudoku-board-select.css
+++ b/app/css/gameplay/board/sudoku-board-select.css
@@ -58,12 +58,6 @@
 
 /* Mode toggle button */
 #sudoku-mode-toggle {
-  position: fixed;
-  bottom: 80px;
-  right: 20px;
-  left: auto;
-  top: auto;
-  transform: none;
   background-color: #333;
   color: white;
   border: none;
@@ -71,7 +65,6 @@
   padding: 6px 15px;
   font-size: 14px;
   cursor: pointer;
-  z-index: 1000;
   display: flex;
   align-items: center;
   box-shadow: 0 2px 5px rgba(0,0,0,0.2);

--- a/app/css/ui/game-menu.css
+++ b/app/css/ui/game-menu.css
@@ -25,10 +25,6 @@
 }
 
 .menu-toggle {
-  position: fixed;
-  top: 0.5rem;
-  left: 0.5rem;
-  z-index: 1100;
   background: #333;
   color: #fff;
   border: none;

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -84,10 +84,6 @@ aside.right-column {
 
 
 .mission-toggle {
-    position: fixed;
-    bottom: 0.5rem;
-    right: 0.5rem;
-    z-index: 1100;
     background: #333;
     color: #fff;
     border: none;
@@ -126,10 +122,7 @@ aside.right-column {
         transition: transform 0.3s;
     }
 
-    #mission-toggle {
-        bottom: 0.5rem;
-        right: 0.5rem;
-    }
+
 }
 
 @media (max-width: 480px) {

--- a/app/css/ui/utility-bar.css
+++ b/app/css/ui/utility-bar.css
@@ -1,0 +1,11 @@
+#utility-bar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0.5rem 0;
+}
+
+#utility-bar button {
+  margin: 0;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -29,6 +29,7 @@
 <link rel="stylesheet" href="css/ui/game-menu.css">
 <link rel="stylesheet" href="css/ui/stats-screen.css">
 <link rel="stylesheet" href="css/ui/responsive-layout.css">
+<link rel="stylesheet" href="css/ui/utility-bar.css">
 </head>
 <body>
     <h1>Sudoku Tower Defense</h1>
@@ -76,6 +77,11 @@
 
         </header>
 
+        <div id="utility-bar">
+            <button id="menu-toggle" class="menu-toggle">Menu</button>
+            <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
+        </div>
+
         <main id="game-area">
         <div id="layout-grid">
             <aside class="left-column">
@@ -116,14 +122,12 @@
                 <button id="new-game">New Game</button>
             </nav>
         </div>
-        <button id="menu-toggle" class="menu-toggle">Menu</button>
         <div id="mission-control" class="overlay open">
             <h3>Mission Control</h3>
             <ul id="mission-tips">
                 <li>Scanning board...</li>
             </ul>
         </div>
-        <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
     </div>
     <!-- Load the modules in the correct order -->
 <script src="js/events.js"></script>

--- a/app/js/sudoku-board-select.js
+++ b/app/js/sudoku-board-select.js
@@ -83,10 +83,6 @@
       
       /* Mode toggle button */
       #sudoku-mode-toggle {
-        position: fixed;
-        top: 10px;
-        left: 50%;
-        transform: translateX(-50%);
         background-color: #333;
         color: white;
         border: none;
@@ -94,7 +90,6 @@
         padding: 6px 15px;
         font-size: 14px;
         cursor: pointer;
-        z-index: 1000;
         display: flex;
         align-items: center;
         box-shadow: 0 2px 5px rgba(0,0,0,0.2);
@@ -161,7 +156,8 @@
       modeToggleButton = document.createElement('button');
       modeToggleButton.id = 'sudoku-mode-toggle';
       modeToggleButton.innerHTML = '<span class="icon">🎯</span> Place Mode <span class="keyboard-hint">Tab</span>';
-      document.body.appendChild(modeToggleButton);
+      const bar = document.getElementById('utility-bar') || document.body;
+      bar.appendChild(modeToggleButton);
       
       // Add click handler for mode toggle
       modeToggleButton.addEventListener('click', toggleInteractionMode);


### PR DESCRIPTION
## Summary
- introduce `#utility-bar` container for small control buttons
- style new utility bar
- position mission/menu/mode toggle buttons inside bar
- update CSS to remove absolute positioning for these buttons
- ensure Sudoku mode toggle inserts into the new bar

## Testing
- `npm test` *(fails: jest not found)*
- `npm start` *(fails to run http-server because package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842c34a99088322aeb7aebc7364ae85