### PR TITLE
Adjust h1 on small screens

### DIFF
--- a/app/css/core/styles.css
+++ b/app/css/core/styles.css
@@ -1059,7 +1059,8 @@ button:active {
 
 @media (max-width: 480px) {
     h1 {
-        font-size: 1.5rem;
+        font-size: 1.2rem;
+        margin-bottom: 12px;
     }
 
     #game-container {


### PR DESCRIPTION
## Summary
- tweak small-screen styles so titles take less space

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ca22f4fc8322a654f07b13bc138b