### PR TITLE
Refactor tower animations to Pixi sprites

### DIFF
--- a/app/css/gameplay/towers/tower-animations.css
+++ b/app/css/gameplay/towers/tower-animations.css
@@ -5,59 +5,6 @@
   z-index: 15;
 }
 
-.tower-projectile {
-  position: absolute;
-  transform-origin: center center;
-  font-size: 16px;
-  z-index: 25;
-}
-
-/* Splash effect */
-.splash-effect {
-  position: absolute;
-  border-radius: 50%;
-  background-color: rgba(255, 100, 0, 0.5);
-  z-index: 25;
-  transform: translate(-50%, -50%);
-}
-
-/* Hit effects */
-.hit-effect {
-  position: absolute;
-  transform: translate(-50%, -50%);
-  z-index: 25;
-}
-
-.normal-hit {
-  width: 40%;
-  height: 40%;
-  background-color: rgba(255, 255, 255, 0.7);
-  border-radius: 50%;
-}
-
-.splash-hit {
-  width: 150%;
-  height: 150%;
-  background-color: rgba(255, 100, 0, 0.5);
-  border-radius: 50%;
-}
-
-.poison-hit {
-  width: 80%;
-  height: 80%;
-  background-color: rgba(0, 255, 0, 0.5);
-  border-radius: 50%;
-}
-
-.stun-hit {
-  font-size: 20px;
-  color: yellow;
-  text-shadow: 0 0 5px black;
-}
-
-.critical-hit {
-  font-size: 24px;
-}
 
 /* Projectile container */
 #projectile-container {


### PR DESCRIPTION
## Summary
- switch projectile animations to use PIXI sprites instead of DOM elements
- store sprites in a PIXI.Container
- animate projectiles and hit effects via PIXI ticker
- clean up CSS of old projectile styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ce5d0a548322b9eb7f87ea2ac692