### PR TITLE
Improve layout for tablets

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -42,17 +42,13 @@ aside.right-column {
 
 @media (min-width: 768px) {
     #layout-grid {
-        /*
-         * Give the puzzle the lion's share of the width. The side columns
-         * shrink down to roughly 10% of the viewport each (never smaller
-         * than 80px) so the board can occupy close to 80%.
-         */
-        grid-template-columns: minmax(80px, 10%) 1fr minmax(80px, 10%);
+        /* Middle column reduced to around 40% for better fit on 16:10 displays */
+        grid-template-columns: 30% 40% 30%;
         align-items: start;
     }
 
     #sudoku-board {
-        max-width: 80vw;
+        max-width: 90%;
     }
 }
 
@@ -78,16 +74,29 @@ aside.right-column {
     max-width: 360px;
 }
 
+.board-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+#placement-options {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    background: #333;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
 .next-wave {
     margin-top: 0.5rem;
 }
 
 
 .mission-toggle {
-    position: fixed;
-    bottom: 0.5rem;
-    right: 0.5rem;
-    z-index: 1100;
+    align-self: flex-end;
+    margin-top: 1rem;
     background: #333;
     color: #fff;
     border: none;
@@ -127,8 +136,8 @@ aside.right-column {
     }
 
     #mission-toggle {
-        bottom: 0.5rem;
-        right: 0.5rem;
+        bottom: auto;
+        right: auto;
     }
 }
 

--- a/app/index.html
+++ b/app/index.html
@@ -88,7 +88,8 @@
             </aside>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
-               
+
+                <div class="board-controls">
                 <ul id="tower-selection">
   <li class="tower-option" data-tower-type="1" title="Rapid Tower: Fast-firing with 3x attack speed but lower damage">1️⃣</li>
   <li class="tower-option" data-tower-type="2" title="Slowing Tower: Reduces enemy speed by 30% for 3 seconds">2️⃣</li>
@@ -100,6 +101,8 @@
   <li class="tower-option" data-tower-type="8" title="Sniper Tower: Long range with 20% chance for critical hits">8️⃣</li>
   <li class="tower-option" data-tower-type="9" title="Support Tower: Boosts damage of adjacent towers by 20%">9️⃣</li>
                 </ul>
+                <button id="placement-options" class="placement-options">Options</button>
+                </div>
                 <button id="start-wave" class="next-wave">Next Wave</button>
             </div>
             <aside class="right-column"></aside>
@@ -124,8 +127,8 @@
             <ul id="mission-tips">
                 <li>Scanning board...</li>
             </ul>
+            <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
         </div>
-        <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
     </div>
     <!-- Load the modules in the correct order -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.3.0/pixi.min.js"></script>


### PR DESCRIPTION
## Summary
- adjust layout grid for 16:10 displays
- wrap tower selection with new control bar and add placement options button
- move mission control toggle inside panel
- add supporting styles for board controls

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f73fc030832289b62b545e4ad8e8