### PR TITLE
Improve layout for tablets

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -29,7 +29,7 @@ aside.right-column {
 }
 
 aside.right-column {
-    display: none;
+    display: flex;
 }
 
 .middle-column {
@@ -42,17 +42,13 @@ aside.right-column {
 
 @media (min-width: 768px) {
     #layout-grid {
-        /*
-         * Give the puzzle the lion's share of the width. The side columns
-         * shrink down to roughly 10% of the viewport each (never smaller
-         * than 80px) so the board can occupy close to 80%.
-         */
-        grid-template-columns: minmax(80px, 10%) 1fr minmax(80px, 10%);
+        /* Middle column reduced to around 40% for better fit on 16:10 displays */
+        grid-template-columns: 30% 40% 30%;
         align-items: start;
     }
 
     #sudoku-board {
-        max-width: 80vw;
+        max-width: 90%;
     }
 }
 
@@ -78,16 +74,29 @@ aside.right-column {
     max-width: 360px;
 }
 
+.board-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+#sudoku-mode-toggle {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    background: #333;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
 .next-wave {
     margin-top: 0.5rem;
 }
 
 
 .mission-toggle {
-    position: fixed;
-    bottom: 0.5rem;
-    right: 0.5rem;
-    z-index: 1100;
+    align-self: flex-end;
+    margin-top: 1rem;
     background: #333;
     color: #fff;
     border: none;
@@ -96,40 +105,12 @@ aside.right-column {
     cursor: pointer;
 }
 
-#mission-control.overlay {
-    transform: translateX(100%);
-    visibility: hidden;
-    transition: transform 0.3s, visibility 0s linear 0.3s;
+#mission-control {
+    display: none;
 }
 
-#mission-control.overlay.open {
-    transform: translateX(0);
-    visibility: visible;
-    transition: transform 0.3s;
-}
-
-@media (orientation: portrait) {
-    #mission-control.overlay {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        transform: translateY(100%);
-        visibility: hidden;
-        transition: transform 0.3s, visibility 0s linear 0.3s;
-        z-index: 1000;
-    }
-
-    #mission-control.overlay.open {
-        transform: translateY(0);
-        visibility: visible;
-        transition: transform 0.3s;
-    }
-
-    #mission-toggle {
-        bottom: 0.5rem;
-        right: 0.5rem;
-    }
+#mission-control.open {
+    display: block;
 }
 
 @media (max-width: 480px) {

--- a/app/index.html
+++ b/app/index.html
@@ -84,11 +84,12 @@
                     <div>Currency: <span id="currency-value">100</span></div>
                     <div id="status-message">Place towers to defend against enemies!</div>
                 </div>
-
+                <button id="start-wave" class="next-wave">Next Wave</button>
             </aside>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
-               
+
+                <div class="board-controls">
                 <ul id="tower-selection">
   <li class="tower-option" data-tower-type="1" title="Rapid Tower: Fast-firing with 3x attack speed but lower damage">1️⃣</li>
   <li class="tower-option" data-tower-type="2" title="Slowing Tower: Reduces enemy speed by 30% for 3 seconds">2️⃣</li>
@@ -100,9 +101,18 @@
   <li class="tower-option" data-tower-type="8" title="Sniper Tower: Long range with 20% chance for critical hits">8️⃣</li>
   <li class="tower-option" data-tower-type="9" title="Support Tower: Boosts damage of adjacent towers by 20%">9️⃣</li>
                 </ul>
-                <button id="start-wave" class="next-wave">Next Wave</button>
+                <button id="sudoku-mode-toggle" class="sudoku-mode-toggle">Place Mode</button>
+                </div>
             </div>
-            <aside class="right-column"></aside>
+            <aside class="right-column">
+                <div id="mission-control" class="open">
+                    <h3>Mission Control</h3>
+                    <ul id="mission-tips">
+                        <li>Scanning board...</li>
+                    </ul>
+                    <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
+                </div>
+            </aside>
         </div>
         </main>
         <div id="game-menu" class="overlay">
@@ -119,13 +129,6 @@
             </nav>
         </div>
         <button id="menu-toggle" class="menu-toggle">Menu</button>
-        <div id="mission-control" class="overlay open">
-            <h3>Mission Control</h3>
-            <ul id="mission-tips">
-                <li>Scanning board...</li>
-            </ul>
-        </div>
-        <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
     </div>
     <!-- Load the modules in the correct order -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.3.0/pixi.min.js"></script>

--- a/app/js/ability-system.js
+++ b/app/js/ability-system.js
@@ -190,7 +190,7 @@ const AbilitySystem = (function() {
     // Place the ability bar inside the main game layout so it's
     // positioned close to the board rather than floating over the
     // entire page.
-    const parent = document.querySelector('.middle-column') ||
+    const parent = document.querySelector('.left-column') ||
                    document.getElementById('game-container') ||
                    document.body;
     parent.appendChild(abilityBar);

--- a/app/js/sudoku-board-select.js
+++ b/app/js/sudoku-board-select.js
@@ -158,11 +158,15 @@
   function createModeUI() {
     // Create mode toggle button if it doesn't exist
     if (!modeToggleButton) {
-      modeToggleButton = document.createElement('button');
-      modeToggleButton.id = 'sudoku-mode-toggle';
-      modeToggleButton.innerHTML = '<span class="icon">🎯</span> Place Mode <span class="keyboard-hint">Tab</span>';
-      document.body.appendChild(modeToggleButton);
-      
+      modeToggleButton = document.getElementById('sudoku-mode-toggle');
+      if (!modeToggleButton) {
+        modeToggleButton = document.createElement('button');
+        modeToggleButton.id = 'sudoku-mode-toggle';
+        modeToggleButton.innerHTML = '<span class="icon">🎯</span> Place Mode <span class="keyboard-hint">Tab</span>';
+        const parent = document.querySelector('.board-controls') || document.body;
+        parent.appendChild(modeToggleButton);
+      }
+
       // Add click handler for mode toggle
       modeToggleButton.addEventListener('click', toggleInteractionMode);
     }


### PR DESCRIPTION
## Summary
- adjust layout grid for 16:10 displays
- wrap tower selection with new control bar and add placement options button
- move mission control toggle inside panel
- add supporting styles for board controls
- place mode toggle now grouped with number buttons
- mission control sits in the right column
- ability bar attaches to left column
- next wave button moved under alerts

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845f73fc030832289b62b545e4ad8e8