### PR TITLE
UI layout tweaks

### DIFF
--- a/app/css/core/styles.css
+++ b/app/css/core/styles.css
@@ -156,16 +156,13 @@ h1 {
 }
 
 #mission-control {
-  position: absolute;
-  right: 20px;
-  top: 100px;
-  width: 220px;
+  position: relative;
+  width: 100%;
   background: rgba(20, 20, 40, 0.9);
   color: white;
   font-family: monospace;
   padding: 10px;
   border-radius: 10px;
-  z-index: 1000;
   box-shadow: 0 0 10px #222;
 }
 

--- a/app/css/gameplay/board/sudoku-board-select.css
+++ b/app/css/gameplay/board/sudoku-board-select.css
@@ -58,12 +58,7 @@
 
 /* Mode toggle button */
 #sudoku-mode-toggle {
-  position: fixed;
-  bottom: 80px;
-  right: 20px;
-  left: auto;
-  top: auto;
-  transform: none;
+  position: relative;
   background-color: #333;
   color: white;
   border: none;
@@ -71,7 +66,6 @@
   padding: 6px 15px;
   font-size: 14px;
   cursor: pointer;
-  z-index: 1000;
   display: flex;
   align-items: center;
   box-shadow: 0 2px 5px rgba(0,0,0,0.2);

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -28,8 +28,14 @@ aside.right-column {
     gap: 1rem;
 }
 
+#left-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
 aside.right-column {
-    display: none;
+    display: flex;
 }
 
 .middle-column {
@@ -117,29 +123,6 @@ aside.right-column {
     transition: transform 0.3s;
 }
 
-@media (orientation: portrait) {
-    #mission-control.overlay {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        transform: translateY(100%);
-        visibility: hidden;
-        transition: transform 0.3s, visibility 0s linear 0.3s;
-        z-index: 1000;
-    }
-
-    #mission-control.overlay.open {
-        transform: translateY(0);
-        visibility: visible;
-        transition: transform 0.3s;
-    }
-
-    #mission-toggle {
-        bottom: auto;
-        right: auto;
-    }
-}
 
 @media (max-width: 480px) {
     #game-container {

--- a/app/index.html
+++ b/app/index.html
@@ -84,7 +84,10 @@
                     <div>Currency: <span id="currency-value">100</span></div>
                     <div id="status-message">Place towers to defend against enemies!</div>
                 </div>
-
+                <div id="left-controls">
+                    <button id="start-wave" class="next-wave">Next Wave</button>
+                    <button id="placement-options" class="placement-options">Options</button>
+                </div>
             </aside>
             <div class="middle-column">
                 <div id="sudoku-board"></div>
@@ -101,11 +104,17 @@
   <li class="tower-option" data-tower-type="8" title="Sniper Tower: Long range with 20% chance for critical hits">8️⃣</li>
   <li class="tower-option" data-tower-type="9" title="Support Tower: Boosts damage of adjacent towers by 20%">9️⃣</li>
                 </ul>
-                <button id="placement-options" class="placement-options">Options</button>
                 </div>
-                <button id="start-wave" class="next-wave">Next Wave</button>
             </div>
-            <aside class="right-column"></aside>
+            <aside class="right-column">
+                <div id="mission-control" class="overlay open">
+                    <h3>Mission Control</h3>
+                    <ul id="mission-tips">
+                        <li>Scanning board...</li>
+                    </ul>
+                    <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
+                </div>
+            </aside>
         </div>
         </main>
         <div id="game-menu" class="overlay">
@@ -122,13 +131,6 @@
             </nav>
         </div>
         <button id="menu-toggle" class="menu-toggle">Menu</button>
-        <div id="mission-control" class="overlay open">
-            <h3>Mission Control</h3>
-            <ul id="mission-tips">
-                <li>Scanning board...</li>
-            </ul>
-            <button id="mission-toggle" class="mission-toggle">Hide Tips</button>
-        </div>
     </div>
     <!-- Load the modules in the correct order -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.3.0/pixi.min.js"></script>

--- a/app/js/ability-system.js
+++ b/app/js/ability-system.js
@@ -190,7 +190,8 @@ const AbilitySystem = (function() {
     // Place the ability bar inside the main game layout so it's
     // positioned close to the board rather than floating over the
     // entire page.
-    const parent = document.querySelector('.middle-column') ||
+    const parent = document.querySelector('#left-controls') ||
+                   document.querySelector('.left-column') ||
                    document.getElementById('game-container') ||
                    document.body;
     parent.appendChild(abilityBar);

--- a/app/js/sudoku-board-select.js
+++ b/app/js/sudoku-board-select.js
@@ -161,7 +161,13 @@
       modeToggleButton = document.createElement('button');
       modeToggleButton.id = 'sudoku-mode-toggle';
       modeToggleButton.innerHTML = '<span class="icon">🎯</span> Place Mode <span class="keyboard-hint">Tab</span>';
-      document.body.appendChild(modeToggleButton);
+
+      const controls = document.querySelector('.board-controls');
+      if (controls) {
+        controls.appendChild(modeToggleButton);
+      } else {
+        document.body.appendChild(modeToggleButton);
+      }
       
       // Add click handler for mode toggle
       modeToggleButton.addEventListener('click', toggleInteractionMode);


### PR DESCRIPTION
## Summary
- move Next Wave and Options to the left sidebar
- insert Mission Control inside the right sidebar
- show Place/Highlight toggle with the number buttons
- attach ability UI to the left sidebar
- adjust responsive layout styles

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fdf46d188322a7d1ae6eff1f772c