### PR TITLE
Rearrange board controls

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -82,6 +82,7 @@ aside.right-column {
 
 .board-controls {
     display: flex;
+    flex-direction: column;
     align-items: center;
     gap: 0.5rem;
 }

--- a/app/js/sudoku-board-select.js
+++ b/app/js/sudoku-board-select.js
@@ -83,10 +83,8 @@
       
       /* Mode toggle button */
       #sudoku-mode-toggle {
-        position: fixed;
-        top: 10px;
-        left: 50%;
-        transform: translateX(-50%);
+        position: relative;
+        margin-top: 8px;
         background-color: #333;
         color: white;
         border: none;
@@ -94,11 +92,12 @@
         padding: 6px 15px;
         font-size: 14px;
         cursor: pointer;
-        z-index: 1000;
+        z-index: 1;
         display: flex;
         align-items: center;
         box-shadow: 0 2px 5px rgba(0,0,0,0.2);
         transition: background-color 0.3s;
+        align-self: center;
       }
       
       #sudoku-mode-toggle:hover {


### PR DESCRIPTION
## Summary
- reorganize board controls so tower buttons stack
- keep the mode toggle in the board controls

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68460ba69b3c8322bfe202ab64799da9