### PR TITLE
Move level indicator near mana bar

### DIFF
--- a/app/css/features/abilities.css
+++ b/app/css/features/abilities.css
@@ -113,17 +113,16 @@
     transition: width 0.3s;
 }
 
-/* === Experience Bar - Positioned at top-left === */
+/* === Experience Bar - Aligned with mana bar === */
 .experience-bar {
-    position: fixed;
-    top: 35px;
-    left: 15px;
-    width: 200px;
+    position: relative;
+    width: 300px;
     height: 10px;
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 5px;
     overflow: hidden;
     z-index: 899;
+    margin-top: 0.25rem;
 }
 
 .experience-fill {
@@ -149,8 +148,8 @@
 }
 
 .experience-text {
-    top: 15px;
-    left: 15px;
+    align-self: center;
+    margin-top: 0.25rem;
 }
 
 .level-up-effect {

--- a/app/js/ability-system.js
+++ b/app/js/ability-system.js
@@ -228,23 +228,38 @@ const AbilitySystem = (function() {
     // Check if experience bar already exists
     if (document.getElementById('experience-bar')) return;
     
-    const experienceBar = document.createElement('div');
-    experienceBar.className = 'experience-bar';
-    experienceBar.id = 'experience-bar';
-    
-    const experienceFill = document.createElement('div');
-    experienceFill.className = 'experience-fill';
-    experienceFill.style.height = '100%';
-    experienceBar.appendChild(experienceFill);
-    
-    document.body.appendChild(experienceBar);
-    
+    const parent = document.querySelector('#left-controls') ||
+                   document.querySelector('.left-column') ||
+                   document.getElementById('game-container') ||
+                   document.body;
+
+    const manaBarContainer = document.getElementById('mana-bar-container');
+
     // Create experience text separately
     const experienceText = document.createElement('div');
     experienceText.className = 'experience-text';
     experienceText.id = 'experience-text';
     experienceText.textContent = `Level ${playerLevel} (${playerExperience}/${experienceToNextLevel})`;
-    document.body.appendChild(experienceText);
+    if (manaBarContainer) {
+      parent.insertBefore(experienceText, manaBarContainer);
+    } else {
+      parent.appendChild(experienceText);
+    }
+
+    const experienceBar = document.createElement('div');
+    experienceBar.className = 'experience-bar';
+    experienceBar.id = 'experience-bar';
+
+    const experienceFill = document.createElement('div');
+    experienceFill.className = 'experience-fill';
+    experienceFill.style.height = '100%';
+    experienceBar.appendChild(experienceFill);
+
+    if (manaBarContainer) {
+      parent.insertBefore(experienceBar, manaBarContainer);
+    } else {
+      parent.appendChild(experienceBar);
+    }
     
     // Create level up effect element
     const levelUpEffect = document.createElement('div');


### PR DESCRIPTION
## Summary
- stack level text and experience bar above the mana bar
- align experience bar width with mana bar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460bec86288322b335a065f8ca5092