### PR TITLE
Fix mission control panel width

### DIFF
--- a/app/css/ui/mission-control.css
+++ b/app/css/ui/mission-control.css
@@ -5,6 +5,8 @@
   color: white;
   max-height: calc(100vh - 120px);
   overflow-y: auto;
+  /* Prevent the panel from overflowing its column */
+  max-width: 100%;
 }
 
 #mission-control h3 {

--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -26,6 +26,8 @@ aside.right-column {
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    /* Allow columns to shrink so content doesn't push the Sudoku board */
+    min-width: 0;
 }
 
 #left-controls {
@@ -36,6 +38,8 @@ aside.right-column {
 
 aside.right-column {
     display: flex;
+    /* Prevent the mission panel from forcing extra width */
+    min-width: 0;
 }
 
 .middle-column {
@@ -44,6 +48,8 @@ aside.right-column {
     justify-content: center;
     align-items: center;
     gap: 1rem;
+    /* Avoid Sudoku board overflow when space is tight */
+    min-width: 0;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- let grid columns shrink so the mission control doesn't push on the board
- keep the mission control from overflowing its column

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460bc417bc832291d2d60932f1d8b5