### PR TITLE
Move tower menu under mana

### DIFF
--- a/app/css/ui/responsive-layout.css
+++ b/app/css/ui/responsive-layout.css
@@ -34,6 +34,20 @@ aside.right-column {
     gap: 0.5rem;
 }
 
+#left-controls #tower-selection {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    width: 100%;
+    max-width: 360px;
+    list-style: none;
+    padding-left: 0;
+    gap: 0.5rem;
+}
+
+#left-controls #tower-selection li.tower-option {
+    width: 100%;
+}
+
 aside.right-column {
     display: flex;
 }

--- a/app/index.html
+++ b/app/index.html
@@ -86,13 +86,8 @@
                 </div>
                 <div id="left-controls">
                     <button id="start-wave" class="next-wave">Next Wave</button>
-                </div>
-            </aside>
-            <div class="middle-column">
-                <div id="sudoku-board"></div>
-
-                <div class="board-controls">
-                <ul id="tower-selection">
+                    <div class="board-controls">
+                    <ul id="tower-selection">
   <li class="tower-option" data-tower-type="1" title="Rapid Tower: Fast-firing with 3x attack speed but lower damage">1️⃣</li>
   <li class="tower-option" data-tower-type="2" title="Slowing Tower: Reduces enemy speed by 30% for 3 seconds">2️⃣</li>
   <li class="tower-option" data-tower-type="3" title="Splash Tower: Damages multiple enemies in a small radius">3️⃣</li>
@@ -102,8 +97,12 @@
   <li class="tower-option" data-tower-type="7" title="Gambling Tower: Random chance for bonus damage or currency">7️⃣</li>
   <li class="tower-option" data-tower-type="8" title="Sniper Tower: Long range with 20% chance for critical hits">8️⃣</li>
   <li class="tower-option" data-tower-type="9" title="Support Tower: Boosts damage of adjacent towers by 20%">9️⃣</li>
-                </ul>
+                    </ul>
+                    </div>
                 </div>
+            </aside>
+            <div class="middle-column">
+                <div id="sudoku-board"></div>
             </div>
             <aside class="right-column">
                 <div id="mission-control" class="overlay open">


### PR DESCRIPTION
## Summary
- move tower selection menu inside the left controls panel
- style tower menu grid to fit under mana bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460dabdc7883228939ca2e460e60e0